### PR TITLE
fix: add one-time SDDM user creation service

### DIFF
--- a/config/common-systemd.yml
+++ b/config/common-systemd.yml
@@ -1,0 +1,4 @@
+type: systemd
+system:
+  enabled:
+    - sddm-boot.service

--- a/config/files/usr/etc/sddm/sddm-useradd
+++ b/config/files/usr/etc/sddm/sddm-useradd
@@ -1,0 +1,4 @@
+#!/usr/bin/sh
+
+getent group sddm > /dev/null || groupadd -r sddm
+getent passwd sddm > /dev/null || useradd -r -g sddm -c "SDDM Greeter Account" -d /var/lib/sddm -s /usr/sbin/nologin sddm

--- a/config/recipe-hyprland-nvidia.yml
+++ b/config/recipe-hyprland-nvidia.yml
@@ -25,3 +25,4 @@ modules:
   - from-file: common-scripts.yml
   - from-file: sddm-scripts.yml
   - type: signing
+  - from-file: common-systemd.yml

--- a/config/recipe-hyprland.yml
+++ b/config/recipe-hyprland.yml
@@ -24,3 +24,4 @@ modules:
   - from-file: common-scripts.yml
   - from-file: sddm-scripts.yml
   - type: signing
+  - from-file: common-systemd.yml

--- a/config/recipe-river-nvidia.yml
+++ b/config/recipe-river-nvidia.yml
@@ -22,3 +22,4 @@ modules:
   - from-file: common-scripts.yml
   - from-file: sddm-scripts.yml
   - type: signing
+  - from-file: common-systemd.yml

--- a/config/recipe-river.yml
+++ b/config/recipe-river.yml
@@ -22,3 +22,4 @@ modules:
   - from-file: common-scripts.yml
   - from-file: sddm-scripts.yml
   - type: signing
+  - from-file: common-systemd.yml

--- a/config/recipe-wayfire-nvidia.yml
+++ b/config/recipe-wayfire-nvidia.yml
@@ -24,3 +24,4 @@ modules:
   - from-file: common-scripts.yml
   - from-file: sddm-scripts.yml
   - type: signing
+  - from-file: common-systemd.yml

--- a/config/recipe-wayfire.yml
+++ b/config/recipe-wayfire.yml
@@ -24,3 +24,4 @@ modules:
   - from-file: common-scripts.yml
   - from-file: sddm-scripts.yml
   - type: signing
+  - from-file: common-systemd.yml

--- a/config/sddm-packages.yml
+++ b/config/sddm-packages.yml
@@ -2,3 +2,7 @@ type: rpm-ostree
 install:
   - sddm
   - sddm-themes
+  - qt5-qtgraphicaleffects
+  - qt5-qtquickcontrols2
+  - qt5-qtsvg
+

--- a/config/systemd/system/sddm-boot.service
+++ b/config/systemd/system/sddm-boot.service
@@ -1,0 +1,17 @@
+# Creates an SDDM user before SDDM runs.
+# See:
+# 	- https://github.com/ublue-os/cinnamon/blob/bf44562ddbed670cdd0d03a45ea08bdb8a6e96a7/system_files/usr/lib/systemd/system/ublue-lightdm-workaround.service#L4
+# 	- https://github.com/ublue-os/main/issues/224#issuecomment-1987851271
+
+[Unit]
+Description=Create SDDM user on system boot
+Before=sddm.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/groupadd -r sddm
+ExecStart=/usr/sbin/useradd -r -g sddm -c "SDDM Greeter Account" -d /var/lib/sddm -s /usr/sbin/nologin sddm
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/config/systemd/system/sddm-boot.service
+++ b/config/systemd/system/sddm-boot.service
@@ -9,8 +9,7 @@ Before=sddm.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/groupadd -r sddm
-ExecStart=/usr/sbin/useradd -r -g sddm -c "SDDM Greeter Account" -d /var/lib/sddm -s /usr/sbin/nologin sddm
+ExecStart=/etc/sddm/sddm-useradd
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
Run a oneshot systemd process to create sddm user before SDDM starts. Only necessary for systemds based on ublue-os/base or others without a preconfigured desktop environment.

Added to non-sway recipes.

See:
- https://github.com/ublue-os/main/issues/224#issuecomment-1987851271
- https://github.com/ublue-os/cinnamon/blob/bf44562ddbed670cdd0d03a45ea08bdb8a6e96a7/system_files/usr/lib/systemd/system/ublue-lightdm-workaround.service#L4