### PR TITLE
Clean up installed packages for hyprland image

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -89,12 +89,7 @@ modules:
         - wlr-randr
         - wlsunset
         - brightnessctl
-        - swaylock
-        - swayidle
         - kanshi
-
-      # terminal
-        - foot
 
       # notifications
         - dunst

--- a/recipes/common/hyprland-modules.yml
+++ b/recipes/common/hyprland-modules.yml
@@ -4,7 +4,9 @@ modules:
         - hyprland
         - waybar
         - xdg-desktop-portal-hyprland
-        - brightnessctl
+        - hyprpaper
+        - hyprlock
+        - hypridle
 
     - type: files
       files:

--- a/recipes/common/river-modules.yml
+++ b/recipes/common/river-modules.yml
@@ -5,6 +5,9 @@ modules:
         - waybar
         - xdg-desktop-portal-wlr
         - xdg-desktop-portal-gtk
+        - foot
+        - swaylock
+        - swayidle
 
     - type: files
       files:

--- a/recipes/common/sway-files.yml
+++ b/recipes/common/sway-files.yml
@@ -1,4 +1,0 @@
-type: files
-files:
-  - source: system/sway
-    destination: /

--- a/recipes/common/sway-modules.yml
+++ b/recipes/common/sway-modules.yml
@@ -1,0 +1,11 @@
+modules:
+    - type: rpm-ostree
+      install:
+        - foot
+        - swaylock
+        - swayidle
+
+    - type: files
+      files:
+        - source: system/sway
+          destination: /

--- a/recipes/common/wayfire-modules.yml
+++ b/recipes/common/wayfire-modules.yml
@@ -9,6 +9,9 @@ modules:
         - xdg-desktop-portal-wlr
         - xdg-desktop-portal-gtk
         - adw-gtk3-theme
+        - foot
+        - swaylock
+        - swayidle
         
     - type: files
       files:

--- a/recipes/recipe-sway-gdm.yml
+++ b/recipes/recipe-sway-gdm.yml
@@ -10,4 +10,4 @@ modules:
   - from-file: common/remove-sddm.yml
   - from-file: common/common-modules.yml
   - from-file: common/gdm-modules.yml
-  - from-file: common/sway-files.yml
+  - from-file: common/sway-modules.yml

--- a/recipes/recipe-sway-nvidia-gdm.yml
+++ b/recipes/recipe-sway-nvidia-gdm.yml
@@ -11,7 +11,7 @@ modules:
   - from-file: common/common-modules.yml
   - from-file: common/nvidia-modules.yml
   - from-file: common/gdm-modules.yml
-  - from-file: common/sway-files.yml
+  - from-file: common/sway-modules.yml
   - type: script
     scripts:
       - setswaynvidiaenvironment.sh

--- a/recipes/recipe-sway-nvidia-open-gdm.yml
+++ b/recipes/recipe-sway-nvidia-open-gdm.yml
@@ -11,7 +11,7 @@ modules:
   - from-file: common/common-modules.yml
   - from-file: common/nvidia-open-modules.yml
   - from-file: common/gdm-modules.yml
-  - from-file: common/sway-files.yml
+  - from-file: common/sway-modules.yml
   - type: script
     scripts:
       - setswaynvidiaenvironment.sh

--- a/recipes/recipe-sway-nvidia-open.yml
+++ b/recipes/recipe-sway-nvidia-open.yml
@@ -10,7 +10,7 @@ modules:
   - from-file: common/sddm-modules.yml
   - from-file: common/common-modules.yml
   - from-file: common/nvidia-open-modules.yml
-  - from-file: common/sway-files.yml
+  - from-file: common/sway-modules.yml
   - type: script
     scripts:
       - setswaynvidiaenvironment.sh

--- a/recipes/recipe-sway-nvidia.yml
+++ b/recipes/recipe-sway-nvidia.yml
@@ -10,7 +10,7 @@ modules:
   - from-file: common/sddm-modules.yml
   - from-file: common/common-modules.yml
   - from-file: common/nvidia-modules.yml
-  - from-file: common/sway-files.yml
+  - from-file: common/sway-modules.yml
   - type: script
     scripts:
       - setswaynvidiaenvironment.sh

--- a/recipes/recipe-sway.yml
+++ b/recipes/recipe-sway.yml
@@ -9,4 +9,4 @@ image-version: 40
 modules:
   - from-file: common/sddm-modules.yml
   - from-file: common/common-modules.yml
-  - from-file: common/sway-files.yml
+  - from-file: common/sway-modules.yml


### PR DESCRIPTION
Summary of changes:
1. Hyprland - Added the hyprpaper package to enable setting the wallpaper out of box.
2. Hyprland - Replaced swayidle with the hypridle package.
3. Hyprland - Replaced swaylock with the hyprlock package.
4. Hyprland - Removed foot, as kitty is already installed as a dependency of the hyprland package.
5. Hyprland - Removed duplicate entry for brightnessctl as it's already part of common-modules.
6. Renamed sway-files to sway-modules as it encompasses more than just files now.

Build is passing: https://github.com/sgallag-insta/wayblue/actions/runs/11406564270