### PR TITLE
Fix hypridle still not respecting default config

### DIFF
--- a/files/system/hyprland/usr/share/hyprland/hyprland.conf
+++ b/files/system/hyprland/usr/share/hyprland/hyprland.conf
@@ -189,4 +189,4 @@ exec-once = dbus-update-activation-environment --all
 exec-once = /usr/bin/gnome-keyring-daemon --start --components=secrets
 exec-once = exec /usr/libexec/pam_kwallet_init
 exec-once = waybar & /usr/libexec/xfce-polkit & dunst & nm-applet
-exec-once = hypridle
+exec-once = hypridle -c /etc/xdg/hypr/hypridle.conf


### PR DESCRIPTION
As far as I can tell, hypridle will not respect any config other than `~/.config/hypr/hypridle.conf` unless it is explicitly specified.