### PR TITLE
fix: Add fprintd-pam to base system image

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -31,6 +31,7 @@ modules:
         - mediainfo
         - polkit
         - xfce-polkit 
+        - fprintd-pam
         - xdg-user-dirs
         - dbus-tools
         - dbus-daemon


### PR DESCRIPTION
When the screen is locked/unlocked, I see errors in the logs related to fprintd:
```
PAM unable to dlopen(/lib64/security/pam_fprintd.so): /lib64/security/pam_fprintd.so: cannot open shared object file: No such file or directory
PAM adding faulty module: /lib64/security/pam_fprintd.so
```

Seems like it's related to [this](https://bugzilla.redhat.com/show_bug.cgi?id=505266) bug thread, which has been marked as "not a bug".

There are a couple of fixes, either to run:
`sudo authselect disable-feature with-fingerprint`

or you can install the `fprintd-pam` package. While I don't have a fingerprint reader myself, that seems like something that would make sense to work OOTB. Also it looks like ublue includes it in their main install too.