### PR TITLE
Update default Hyprland configuration for breaking change introduced in F41

### DIFF
--- a/files/system/hyprland/usr/share/hyprland/hyprland.conf
+++ b/files/system/hyprland/usr/share/hyprland/hyprland.conf
@@ -87,7 +87,7 @@ dwindle {
 
 master {
     # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
-    new_is_master = true
+    new_status = master
 }
 
 gestures {


### PR DESCRIPTION
Fixes #68 
Breaking change that necessitated this PR was https://github.com/hyprwm/Hyprland/pull/6479
I did not find any other issues with the default configuration. With this change, Hyprland no longer throws up an error bar.