### PR TITLE
Add NetworkManager-?-gnome packages to common packageset

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -74,7 +74,9 @@ modules:
       # networking
         - network-manager-applet
         - NetworkManager-openvpn
+        - NetworkManager-openvpn-gnome
         - NetworkManager-openconnect
+        - NetworkManager-openconnect-gnome
         - bluez
         - bluez-tools
         - blueman


### PR DESCRIPTION
This fixes #74

This PR adds two packages to the common package recipe. These packages are required to allow nm-applet to be able to configure several NetworkManager modules via the UI.

These packages specifically are the ones that we can pull in that don't add a bunch of other NM modules -- there exist several more for other VPNs and the like should we want them.

Package diff from a test VM on `hyprland:latest`:
```
Added:
  NetworkManager-openconnect-gnome-1.2.10-6.fc41.x86_64
  NetworkManager-openvpn-gnome-1:1.12.0-2.fc41.x86_64
  gcr3-3.41.1-9.fc41.x86_64
  gcr3-base-3.41.1-9.fc41.x86_64
  harfbuzz-icu-9.0.0-3.fc41.x86_64
  hyphen-2.8.8-25.fc41.x86_64
  javascriptcoregtk4.1-2.46.3-1.fc41.x86_64
  libatomic-14.2.1-3.fc41.x86_64
  libmanette-0.2.9-1.fc41.x86_64
  libnma-gtk4-1.10.6-8.fc41.x86_64
  webkit2gtk4.1-2.46.3-1.fc41.x86_64
  woff2-1.0.2-20.fc41.x86_64
```