### PR TITLE
Stop hyprland from invoking duplicate services

### DIFF
--- a/files/system/hyprland/usr/share/hyprland/hyprland.conf
+++ b/files/system/hyprland/usr/share/hyprland/hyprland.conf
@@ -184,12 +184,25 @@ bind = $mainMod, mouse_up, workspace, e-1
 bindm = $mainMod, mouse:272, movewindow
 bindm = $mainMod, mouse:273, resizewindow
 
+#
+# These services should be started by default by systemd when
+# graphical-session.target is reached. If you prefer to launch via tty, you'll
+# want to turn these back on, otherwise screensharing and the like may be
+# broken.
+#
+# For a complete list of units systemd spawns for you, run this command:
+#   systemctl --user list-dependencies graphical-session.target
+#
+# Any service under basic.target you'll get in a tty, but you'll need to log in
+# through your DM to get graphical-session.target
+#
+#exec-once = /usr/libexec/xdg-desktop-portal-hyprland
+#exec-once = /usr/libexec/xdg-desktop-portal-gtk
+#exec-once = /usr/libexec/xdg-desktop-portal
+#exec-once = dunst
 
-exec-once = /usr/libexec/xdg-desktop-portal-hyprland
-exec-once = /usr/libexec/xdg-desktop-portal-gtk
-exec-once = /usr/libexec/xdg-desktop-portal
 exec-once = dbus-update-activation-environment --all
 exec-once = /usr/bin/gnome-keyring-daemon --start --components=secrets
 exec-once = exec /usr/libexec/pam_kwallet_init
-exec-once = waybar & /usr/libexec/xfce-polkit & dunst & nm-applet
+exec-once = waybar & /usr/libexec/xfce-polkit & nm-applet
 exec-once = hypridle -c /etc/xdg/hypr/hypridle.conf


### PR DESCRIPTION
Related to #80
Noissue

The services removed from `hyprland.conf` in this commit are also spawned by systemd when a user logs in and can cause breakage if Hyprland starts them manually. In theory, most of these daemons should detect that they're duplicates and fail, but I'd rather not have the potential for race conditions.

For reference, here's a depgraph of Hyprland's `graphical-session.target`:

```
$ systemctl --user list-dependencies graphical-session.target
graphical-session.target
● ├─at-spi-dbus-bus.service
● ├─dunst.service
● ├─flatpak-portal.service
● ├─flatpak-session-helper.service
● ├─gvfs-daemon.service
○ ├─uresourced.service
● ├─xdg-desktop-portal-hyprland.service
● ├─xdg-desktop-portal.service
● ├─xdg-document-portal.service
● ├─xdg-permission-store.service
● └─basic.target
●   ├─systemd-tmpfiles-setup.service
●   ├─paths.target
●   ├─sockets.target
●   │ ├─dbus.socket
●   │ ├─pipewire-pulse.socket
●   │ └─pipewire.socket
●   └─timers.target
●     ├─grub-boot-success.timer
●     └─systemd-tmpfiles-clean.timer
```

It's also worth noting that every session -- graphical or otherwise -- gets Pipewire for free. None of the compositors should be launching it themselves, as that can lead to the screensharing failures mentioned in #80. This wasn't the case for Hyprland, but it's worth noting.

I believe the configuration lines are still useful for users launching from a tty and so left them in, commented out for reference.