### PR TITLE
fix: remove obsoleted adwaita-qt5 package

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -112,7 +112,6 @@ modules:
         - dunst
 
       # theme and GUI
-        - adwaita-qt5
         - fontawesome-fonts-all
         - gnome-themes-extra
         - gnome-icon-theme


### PR DESCRIPTION
It's blocking builds:

installed package qt5-qtbase-gui-5.15.15-3.fc41.x86_64 obsoletes adwaita-qt5 <= 1.4.2 provided by adwaita-qt5-1.4.2-8.fc41.x86_64 from fedora