### PR TITLE
chore: switch from power-profiles-daemon to tuned

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -39,7 +39,7 @@ modules:
         - rofi-wayland
 
       # environment
-        - power-profiles-daemon
+        - tuned-ppd
         - xorg-x11-server-Xwayland
         - headsetcontrol
         - mediainfo


### PR DESCRIPTION
Based on this issue: https://github.com/wayblueorg/wayblue/issues/88

Manually verified that the default waybar config is still working even with this switch