### PR TITLE
fix(rpm-ostree): pin rpm-ostree to 2025.12-1

### DIFF
--- a/files/scripts/pinrpmostree.sh
+++ b/files/scripts/pinrpmostree.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -oue pipefail
+
+RPM_OSTREE_VERSION="2025.12-1"
+
+dnf install -y --from-repo=updates-archive \
+  "rpm-ostree-${RPM_OSTREE_VERSION}.fc${OS_VERSION}" \
+  "rpm-ostree-libs-${RPM_OSTREE_VERSION}.fc${OS_VERSION}"

--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -8,6 +8,8 @@ modules:
     - type: script
       scripts:
         - installsignedkernel.sh
+        # remove line below once rpm-ostree is fixed
+        - pinrpmostree.sh
 
     - type: dnf
       install:


### PR DESCRIPTION
https://github.com/coreos/rpm-ostree/issues/5567

This will also require an announcement to all wayblue users via discord and github releases so they can run mitigation steps