### PR TITLE
chore: switch hyprland-modules to wayblueorg copr

### DIFF
--- a/recipes/common/hyprland-modules.yml
+++ b/recipes/common/hyprland-modules.yml
@@ -3,7 +3,7 @@ modules:
       repos:
         copr:
           enable:
-            - solopasha/hyprland
+            - craftidore/wayblueorg-hyprland
       install:
         install-weak-deps: false
         packages:
@@ -14,7 +14,7 @@ modules:
         - hyprpaper
         - hyprlock
         - hypridle
-        - hyprland-qtutils
+        - hyprland-guiutils
 
     - type: files
       files:


### PR DESCRIPTION
Switching hyprland images over to the wayblueorg hyprlandRPM copr source. This source also supports fedora 44, whenever the switch happens.

Additionally, hyprland-qtutils was renamed hyprland-guiutils in recent versions of hyprland.

I have locally tested builds of

- recipe-hyprland.yml
- recipe-hyprland-nvidia.yml
- recipe-hyprland-gdm.yml